### PR TITLE
Update the peru currency symbol as defined in the wikipedia: 

### DIFF
--- a/currency-format.json
+++ b/currency-format.json
@@ -1333,12 +1333,12 @@
     "name": "Nuevo Sol",
     "fractionSize": 2,
     "symbol": {
-      "grapheme": "S/.",
+      "grapheme": "S/",
       "template": "$1",
       "rtl": false
     },
     "uniqSymbol": {
-      "grapheme": "S/.",
+      "grapheme": "S/",
       "template": "$1",
       "rtl": false
     }


### PR DESCRIPTION
Update the Peru currency Symbol for New Sol from `S/.` to `S/` as defined in the wikipedia: https://en.wikipedia.org/wiki/Peruvian_nuevo_sol
