### PR TITLE
Update out-of-date currency codes

### DIFF
--- a/currency-format.json
+++ b/currency-format.json
@@ -1153,11 +1153,19 @@
     "symbol": null,
     "uniqSymbol": null
   },
-  "MRO": {
+  "MRU": {
     "name": "Ouguiya",
     "fractionSize": 2,
-    "symbol": null,
-    "uniqSymbol": null
+    "symbol": {
+      "grapheme": "UM",
+      "template": "1 $",
+      "rtl": true
+    },
+    "uniqSymbol": {
+      "grapheme": "أوقية",
+      "template": "1 $",
+      "rtl": true
+    }
   },
   "MUR": {
     "name": "Mauritius Rupee",
@@ -1591,10 +1599,14 @@
     "symbol": null,
     "uniqSymbol": null
   },
-  "STD": {
+  "STN": {
     "name": "Dobra",
     "fractionSize": 2,
-    "symbol": null,
+    "symbol": {
+      "grapheme": "Db",
+      "template": "$1",
+      "rtl": false
+    },
     "uniqSymbol": null
   },
   "SVC": {
@@ -1797,7 +1809,7 @@
     "symbol": null,
     "uniqSymbol": null
   },
-  "UYU": {
+  "UYW": {
     "name": "Peso Uruguayo",
     "fractionSize": 0,
     "symbol": {


### PR DESCRIPTION
I found that these three codes had been replaced in ISO 4217, so have updated these.  I've tried to add in the extra info (text direction etc), although I'm not 100% sure about those details - maybe you have a source to check this?